### PR TITLE
restricting the root url pattern

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,11 @@ import (
 )
 
 func home(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+
 	fmt.Fprintf(w, "Hello from Snippetbox")
 }
 
@@ -15,7 +20,7 @@ func snippetView(w http.ResponseWriter, r *http.Request) {
 }
 
 func snippetCreate(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Create a new snippet...") 
+	fmt.Fprintf(w, "Create a new snippet...")
 }
 
 func main() {
@@ -23,7 +28,7 @@ func main() {
 	mux.HandleFunc("/", home)
 	mux.HandleFunc("/snippet/create", snippetCreate)
 	mux.HandleFunc("/snippet/view", snippetView)
-	
+
 	log.Println("Starting server on :4000")
 	err := http.ListenAndServe(":4000", mux)
 	log.Fatal(err)


### PR DESCRIPTION
### Restricting the root url pattern
There are two types of patterns: **fixed** and **subtree**. Fixed patterns match exactly a specific path ("/snippet/create", "/snippet/view"), while subtree patterns ("/") match any path that starts with a specific substring and ends with a trailing forward slash.

The "/" subtree pattern is special because it matches any path, even if it does not exist. Because of this, it acts as a catch-all, meaning that all requests that do not match a fixed pattern are handled through that pattern.

So to restrict the behavior of the subtree pattern to show only the home page. Instead of changing the behavior of Go's servemux, a simple check can be added in the home page controller to show the home page only when the path exactly matches "/" and return a 404 error response for all other paths. This ensures that the "/" subtree pattern does not handle all requests, but only those that exactly match the home page path.

```go
func home(w http.ResponseWriter, r *http.Request) {
	if r.URL.Path != "/" {
		http.NotFound(w, r)
		return
	}

	fmt.Fprintf(w, "Hello from Snippetbox")
}
```

