### PR TITLE
add POST method validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,12 @@ func snippetView(w http.ResponseWriter, r *http.Request) {
 }
 
 func snippetCreate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		fmt.Fprintf(w, http.StatusText(http.StatusMethodNotAllowed))
+		return
+	}
+
 	fmt.Fprintf(w, "Create a new snippet...")
 }
 


### PR DESCRIPTION
### Add POST method validation
To prevent unauthorized access to fragment creation. If a non-POST HTTP request is received, a 405 status code (method not allowed) is returned and an error message is written to the HTTP response. This additional security measure helps prevent potential vulnerabilities in the application and protects the fragment creation functionality from unauthorized access.