### PR TITLE
Customization of the snippetCreate header

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func snippetView(w http.ResponseWriter, r *http.Request) {
 
 func snippetCreate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		fmt.Fprintf(w, http.StatusText(http.StatusMethodNotAllowed))
 		return


### PR DESCRIPTION
### Implementación de la cabecera personalizada Allow en el manejador snippetCreate
In the **snippetCreate** handler, a custom **Allow** header has been created using the **w.Header().Set()** method that is added to the HTTP response header map in case a non-allowed HTTP request is received. The Allow header provides the user with a list of allowed request methods for a given URL in the application, in this case for creating snippetCreate.