### PR TITLE
using the shortcut http.Error

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func snippetCreate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		w.WriteHeader(http.StatusMethodNotAllowed)
-		fmt.Fprintf(w, http.StatusText(http.StatusMethodNotAllowed))
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 		return
 	}
 


### PR DESCRIPTION
### The http.Error shortcut
If you want to send a **status code other than 200** and a plain text response body, it is a good opportunity to use the **http.Error() shortcut**. This is a lightweight helper function that takes a given message and status code, and calls the **w.WriteHeader()** and **w.Write()** methods behind the scenes for us.