### PR TITLE
url query strings for snippet view

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 )
 
 func home(w http.ResponseWriter, r *http.Request) {
@@ -16,7 +17,13 @@ func home(w http.ResponseWriter, r *http.Request) {
 }
 
 func snippetView(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Display a specific snippet...")
+	id, err := strconv.Atoi(r.URL.Query().Get("id"))
+	if err != nil || id < 1 {
+		http.NotFound(w, r)
+		return
+	}
+
+	fmt.Fprintf(w, "Display a specific snippet with ID %d...", id)
 }
 
 func snippetCreate(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### URL query strings for snippet view
Query strings are a way of passing information through the **URL** in an **HTTP GET** request. When a **GET** request is made to a web server, the **URL** includes a query string that is specified after the **URL** path and begins with a question mark **?**.