### PR TITLE
Disabling directory listings

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -3,12 +3,13 @@ package main
 import (
 	"log"
 	"net/http"
+	"path/filepath"
 )
 
 func main() {
 	mux := http.NewServeMux()
 
-	fileServer := http.FileServer(http.Dir("./ui/static"))
+	fileServer := http.FileServer(neuteredFileSystem{http.Dir("./ui/static")})
 	mux.Handle("/static/", http.StripPrefix("/static", fileServer))
 
 	mux.HandleFunc("/", home)
@@ -18,4 +19,30 @@ func main() {
 	log.Println("Starting server on :4000")
 	err := http.ListenAndServe(":4000", mux)
 	log.Fatal(err)
+}
+
+type neuteredFileSystem struct {
+	fs http.FileSystem
+}
+
+func (nfs neuteredFileSystem) Open(path string) (http.File, error) {
+	f, err := nfs.fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := f.Stat()
+	if s.IsDir() {
+		index := filepath.Join(path, "index.html")
+		if _, err := nfs.fs.Open(index); err != nil {
+			closeErr := f.Close()
+			if closeErr != nil {
+				return nil, closeErr
+			}
+
+			return nil, err
+		}
+	}
+
+	return f, nil
 }


### PR DESCRIPTION
## Disabling directory listings

### What is it for?
The code creates a custom solution to prevent the web server from displaying directory listings when a user accesses a directory without an index file (such as index.html). Instead of displaying the list of files in the directory, a 404 (Not Found) error is returned when a directory without an index file is requested.

### Why?
For security and presentation reasons, it is often desirable to disable the ability to list the contents of a directory on a web server. This prevents users from seeing a list of files in a directory and instead provides a 404 error if an index file is not found, improving security and user experience.

The custom solution is achieved by creating a neuteredFileSystem type, which implements the http.FileSystem interface and overrides the Open() method. When a request for a resource is received, this method checks if the resource is a directory and if it contains an index file. If an index file is not found, a 404 error is returned. If an index file is found, the file is delivered as you would expect on a standard web server.

In summary, this custom code allows you to control how directory requests are handled on a Go web server by replacing directory listings with 404 errors when an index file is not found.